### PR TITLE
Add rust-toolchain.toml

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly-2024-02-04"


### PR DESCRIPTION
stdsimd is no longer supported by rust, setting toolchain to older version resolves the compilation issue, allowing for seamless compilation on other OSes (tested on linux)